### PR TITLE
Change non-standard form=binary to standard access=stream.

### DIFF
--- a/seismic_ADEPML_2D_elastic_RK4_eighth_order.f90
+++ b/seismic_ADEPML_2D_elastic_RK4_eighth_order.f90
@@ -950,13 +950,13 @@ do it = 1,NSTEP
       snapvx = vx(1:NX,1:NY)
       snapvy = vy(1:NX,1:NY)
       write(routine,'(a12,i5.5,a9)') './snapshots/',it,'snapVx.su'
-      open(21,file=routine,form='binary')
+      open(21,file=routine,access='stream')
          do j = 1,NX,1
             write(21) head,(real(snapvx(k,j)),k=1,NY)
          enddo
       close(21)
       write(routine,'(a12,i5.5,a9)') './snapshots/',it,'snapVy.su'
-      open(21,file=routine,form='binary')
+      open(21,file=routine,access='stream')
          do j = 1,NX,1
             write(21) head,(real(snapvy(k,j)),k=1,NY)
          enddo
@@ -1001,12 +1001,12 @@ seisvy = sisvy
 head=0
 head(58)=nstep
 head(59)=deltat*1e6
-open(21,file='./seismograms/seisVx.su',form='binary')
+open(21,file='./seismograms/seisVx.su',access='stream')
    do j=1,NREC,1
       write(21) head,(real(seisvx(k,j)),k=1,nstep)
    enddo
 close(21)
-open(21,file='./seismograms/seisVy.su',form='binary')
+open(21,file='./seismograms/seisVy.su',access='stream')
    do j=1,NREC,1
       write(21) head,(real(seisvy(k,j)),k=1,nstep)
    enddo


### PR DESCRIPTION
This change is to support building on gfortran which doesn't support `form='binary'`.

Documentation of the F2003 standard comes from:
- http://www.j3-fortran.org/doc/year/04/04-007.txt
  (Search for `199.2.2.3 Stream access`)

- https://gcc.gnu.org/onlinedocs/gcc-5.1.0/gfortran/Fortran-2003-status.html#Fortran-2003-status
> The OPEN statement supports the ACCESS='STREAM' specifier, allowing I/O without any record structure.

- http://www.oracle.com/technetwork/server-storage/solaris10/f2k-140697.html
  (Search for `Stream I/O access`)